### PR TITLE
Validate single-layer input and harden zero-sum check in transform_pmf

### DIFF
--- a/R/01-transform_pmf.R
+++ b/R/01-transform_pmf.R
@@ -10,6 +10,7 @@
 
   # Input type validation - using parent function param name 'x'
   .assert_class(x, "SpatRaster", "x")
+  .assert_length(terra::nlyr(x), 1, "x")
 
   # Check for all NA values
   if (all(is.na(terra::values(x)))) {
@@ -22,7 +23,7 @@
 
   # Check for zero sum
   total <- terra::global(x, "sum", na.rm = TRUE)$sum
-  if (total == 0) {
+  if (isTRUE(total == 0)) {
     stop("Sum of all values in 'x' is zero - cannot create PMF")
   }
 

--- a/tests/testthat/test-01-transform_pmf.R
+++ b/tests/testthat/test-01-transform_pmf.R
@@ -50,6 +50,9 @@ test_that("transform_pmf errors on invalid inputs", {
 
   all_zero_rast <- create_test_raster(rep(0, 4), 2, 2)
   expect_error(transform_pmf(all_zero_rast), "Sum of all values in 'x' is zero - cannot create PMF")
+
+  multi_layer <- c(all_zero_rast, all_zero_rast)
+  expect_error(transform_pmf(multi_layer), "x must have length 1")
 })
 
 test_that("transform_pmf preserves relative proportions", {


### PR DESCRIPTION
### Motivation
- Prevent ambiguous or vectorized behavior when a multi-layer `SpatRaster` is passed to `transform_pmf()` and ensure scalar checks are robust. 

### Description
- Add explicit single-layer validation by calling `.assert_length(terra::nlyr(x), 1, "x")` inside `.chck_transform_pmf()` to enforce the documented contract that `transform_pmf()` accepts a single raster layer. 
- Make the zero-sum check scalar-safe by using `isTRUE(total == 0)` before erroring. 
- Add a regression test in `tests/testthat/test-01-transform_pmf.R` that asserts a multi-layer raster produces a clear validation error (`"x must have length 1"`).

### Testing
- Added a unit test (`tests/testthat/test-01-transform_pmf.R`) covering the multi-layer input case, but the test suite was not executed here. 
- Attempted to run `testthat::test_dir("tests/testthat")` via `R -q -e`, which failed because `R` is not available in this environment (`/bin/bash: R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2eed6cc00832d81a8768f109e8b9d)