### PR TITLE
Update tests: refine calc_normalize checks and add iterative iFCA tests

### DIFF
--- a/tests/testthat/test-01-normalize_functions.R
+++ b/tests/testthat/test-01-normalize_functions.R
@@ -172,7 +172,7 @@ test_that("calc_normalize preserves raster properties", {
 test_that("calc_normalize handles edge cases appropriately", {
   # Test with negative values
   neg_weights <- c(-1, -2, -3)
-  expect_error(calc_normalize(neg_weights, "standard"), NA) # Should not error
+  expect_no_error(calc_normalize(neg_weights, "standard"))
 
   # Test with single value
   single_weight <- 5
@@ -183,21 +183,12 @@ test_that("calc_normalize handles edge cases appropriately", {
   expect_true(all(is.na(calc_normalize(all_na, "standard"))))
 })
 
-# Performance tests
-test_that("calc_normalize performs efficiently with large datasets", {
-  skip_on_ci()
+# Large input behavior (structure-focused, non-timing)
+test_that("calc_normalize handles larger rasters without changing structure", {
+  large_raster <- create_test_raster(100, 100, 5)
 
-  # Create large raster
-  large_raster <- create_test_raster(1000, 1000, 5)
-
-  # Test performance
-  expect_lt(
-    system.time(calc_normalize(large_raster, "standard"))[["elapsed"]],
-    5 # Should complete in less than 5 seconds
-  )
-
-  # Test snap mode performance improvement - not improve
-  # time_normal <- system.time(calc_normalize(large_raster, "standard", snap = FALSE))
-  # time_snap <- system.time(calc_normalize(large_raster, "standard", snap = TRUE))
-  # expect_lt(time_snap[["elapsed"]], time_normal[["elapsed"]])
+  result <- calc_normalize(large_raster, "standard")
+  expect_s4_class(result, "SpatRaster")
+  expect_equal(dim(result), dim(large_raster))
+  expect_equal(names(result), names(large_raster))
 })

--- a/tests/testthat/test-03-iterative_chain.R
+++ b/tests/testthat/test-03-iterative_chain.R
@@ -1,0 +1,93 @@
+# tests/testthat/test-03-iterative_chain.R
+
+create_ifca_test_data <- function() {
+  demand <- terra::rast(nrows = 3, ncols = 3)
+  terra::values(demand) <- c(10, 20, 30, 40, 50, 60, 70, 80, 90)
+
+  d1 <- terra::rast(nrows = 3, ncols = 3)
+  d2 <- terra::rast(nrows = 3, ncols = 3)
+  terra::values(d1) <- c(1, 2, 3, 2, 3, 4, 3, 4, 5)
+  terra::values(d2) <- c(5, 4, 3, 4, 3, 2, 3, 2, 1)
+  distance <- c(d1, d2)
+  names(distance) <- c("f1", "f2")
+
+  list(
+    demand = demand,
+    distance = distance,
+    supply = c(10, 15)
+  )
+}
+
+test_that(".help_prep_facilities and .help_add_0facilities handle zero supply", {
+  td <- create_ifca_test_data()
+  supply <- c(10, 0)
+
+  processed <- .help_prep_facilities(supply, td$distance)
+  expect_equal(processed$supply, 10)
+  expect_equal(length(processed$zero_map), 2)
+  expect_equal(terra::nlyr(processed$distances), 1)
+
+  restored <- .help_add_0facilities(results = 99, zero_map = processed$zero_map, fill = 0)
+  expect_equal(restored, c(99, 0))
+})
+
+test_that(".chck_spax_ifca validates key constraints", {
+  td <- create_ifca_test_data()
+
+  expect_no_error(
+    .chck_spax_ifca(
+      distance_raster = td$distance,
+      demand = td$demand,
+      supply = td$supply,
+      decay_params = list(method = "gaussian", sigma = 2),
+      lambda = 0.5,
+      max_iter = 10,
+      tolerance = 1e-4,
+      window_size = 3
+    )
+  )
+
+  expect_error(
+    .chck_spax_ifca(
+      distance_raster = td$distance,
+      demand = td$demand,
+      supply = td$supply,
+      decay_params = list(method = "gaussian", sigma = 2),
+      lambda = 1.2,
+      max_iter = 10,
+      tolerance = 1e-4,
+      window_size = 3
+    ),
+    "lambda must be between"
+  )
+})
+
+test_that("spax_ifca snap path and full path return expected structures", {
+  td <- create_ifca_test_data()
+
+  fast <- spax_ifca(
+    distance_raster = td$distance,
+    demand = td$demand,
+    supply = td$supply,
+    decay_params = list(method = "gaussian", sigma = 2),
+    max_iter = 8,
+    window_size = 3,
+    snap = TRUE
+  )
+  expect_type(fast, "double")
+  expect_equal(length(fast), 2)
+
+  full <- spax_ifca(
+    distance_raster = td$distance,
+    demand = td$demand,
+    supply = td$supply,
+    decay_params = list(method = "gaussian", sigma = 2),
+    max_iter = 8,
+    window_size = 3,
+    snap = FALSE
+  )
+  expect_s3_class(full, "spax")
+  expect_equal(full$type, "iFCA")
+  expect_s4_class(full$accessibility, "SpatRaster")
+  expect_true(all(c("id", "utilization", "ratio", "attractiveness") %in% names(full$facilities)))
+})

--- a/tests/testthat/test-03-spax_e2sfca.R
+++ b/tests/testthat/test-03-spax_e2sfca.R
@@ -119,8 +119,8 @@ test_that(".chck_compute_access validates inputs correctly", {
       td$supply_df,
       demand_weights,
       access_weights,
-      id_col = "id", # Added this
-      supply_cols = c("doctors", "nurses") # Added this
+      id_col = "id",
+      supply_cols = c("doctors", "nurses")
     ),
     "demand must be one of the following classes: SpatRaster"
   )
@@ -133,8 +133,8 @@ test_that(".chck_compute_access validates inputs correctly", {
       td$supply_df,
       wrong_weights,
       access_weights,
-      id_col = "id", # Added this
-      supply_cols = c("doctors", "nurses") # Added this
+      id_col = "id",
+      supply_cols = c("doctors", "nurses")
     ),
     "Length of demand_weights layers \\(1\\) must match length of facilities \\(2\\)"
   )


### PR DESCRIPTION
### Motivation

- Tighten expectations around `calc_normalize` to assert correct behavior rather than timing or CI-sensitive assumptions.
- Add focused tests for the iterative iFCA chain to cover helper functions, validation and both `snap` and full execution paths.
- Clean up small formatting/comment inconsistencies in existing validation tests to improve readability.

### Description

- Replaced an `expect_error(..., NA)` usage with `expect_no_error(calc_normalize(...))` to more clearly express the expectation for negative-weight handling. 
- Reworked the performance test into a structure-focused test that uses `create_test_raster(100, 100, 5)` and asserts the result is a `SpatRaster` with matching `dim` and `names`, and removed timing assertions and `skip_on_ci()`.
- Added a new test file `tests/testthat/test-03-iterative_chain.R` that includes tests for `.help_prep_facilities`, `.help_add_0facilities`, `.chck_spax_ifca`, and `spax_ifca` covering both `snap = TRUE` and `snap = FALSE` paths and expected output structures. 
- Minor formatting/comment cleanup in `tests/testthat/test-03-spax_e2sfca.R` to remove stray inline comments and ensure consistent parameter lines.

### Testing

- Ran the package test suite with `devtools::test()` (the `testthat` tests) after the changes. 
- All updated unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f2557018832daf145c22c0e11aef)